### PR TITLE
reuse OSCAR service token for terminal auth

### DIFF
--- a/crates/ghostty-web/README.md
+++ b/crates/ghostty-web/README.md
@@ -2,7 +2,7 @@
 
 This crate deploys an OSCAR exposed service that provides a browser-based terminal powered by `ghostty-web`. The terminal runs inside the service container and includes `oscar-cli`, `tmux`, and a standard Bash shell.
 
-The service is intended to be deployed per user. Access is controlled by the application itself using a token passed in the URL, similar to the access pattern used by Jupyter notebooks.
+The service is intended to be deployed per user. By default, the launcher reads the OSCAR service access token from the mounted service FDL and reuses it as the terminal access token, so the browser login token matches the service token managed by OSCAR.
 
 The container can also preconfigure `oscar-cli` against the in-cluster OSCAR API by injecting an OIDC refresh token as a secret.
 
@@ -39,7 +39,6 @@ oscar-cli apply fdl.yml
 
 Before deploying, replace the placeholder secrets in `fdl.yml`:
 
-- `TERMINAL_TOKEN`: token used to access the terminal URL
 - `OSCAR_OIDC_REFRESH_TOKEN`: OIDC refresh token used by `oscar-cli`
 
 Persistent workspace:
@@ -53,7 +52,7 @@ Persistent workspace:
 After deployment, access the service through:
 
 ```text
-https://<OSCAR-ENDPOINT>/system/services/<service-name>/exposed/?token=<your-token>
+https://<OSCAR-ENDPOINT>/system/services/<service-name>/exposed/?token=<service-token>
 ```
 
 On first access, the server validates the token, issues an `HttpOnly` session cookie, and redirects the browser to the same URL without the `token` query parameter. The WebSocket terminal then reuses that cookie.
@@ -74,6 +73,8 @@ default: local-cluster
 - This crate assumes one deployed instance per user.
 - The service is stateful from the user's point of view if a bucket is mounted, even though the exposed service itself runs as a single pod.
 - If your OSCAR cluster expects `port` instead of `api_port` in the `expose` block, replace that key accordingly.
-- If `TERMINAL_TOKEN` is empty, the application-side authentication is disabled and the terminal becomes publicly accessible.
+- The launcher reads the token from `/oscar/config/function_config.yaml` by default. You can override that path with `OSCAR_SERVICE_FDL_PATH`.
+- If the launcher cannot read a token from the OSCAR FDL, it falls back to `TERMINAL_TOKEN` if that environment variable is already present.
+- If neither the OSCAR service token nor `TERMINAL_TOKEN` is available, the application-side authentication is disabled and the terminal becomes publicly accessible.
 - The generated `oscar-cli` config is written to `~/.config/oscar/config.yaml` inside the container and uses mode `0600`.
 - If you mount `/mnt`, the workspace can persist independently from the in-container credentials. Review whether you want the generated CLI config to persist together with that workspace.

--- a/crates/ghostty-web/docker/server.js
+++ b/crates/ghostty-web/docker/server.js
@@ -595,7 +595,7 @@ function sendUnauthorizedPage(res, basePath) {
   <body>
     <main>
       <h1>Token required</h1>
-      <p>This terminal requires a valid access token in the URL.</p>
+      <p>This terminal requires the OSCAR service token in the URL.</p>
       <p>Open <code>${escapeHtml(tokenHint)}</code> and the server will exchange the token for a session cookie.</p>
     </main>
   </body>

--- a/crates/ghostty-web/fdl.yml
+++ b/crates/ghostty-web/fdl.yml
@@ -17,7 +17,6 @@ functions:
           OSCAR_CLUSTER_ENDPOINT: http://oscar.oscar.svc.cluster.local:8080
           OSCAR_CLUSTER_SSL_VERIFY: "false"
         secrets:
-          TERMINAL_TOKEN: change-me
           OSCAR_OIDC_REFRESH_TOKEN: change-me
       mount:
         storage_provider: minio.default

--- a/crates/ghostty-web/script.sh
+++ b/crates/ghostty-web/script.sh
@@ -6,6 +6,7 @@ SERVICE_NAME="${SERVICE_NAME:-ghostty-web}"
 BASE_PATH="${BASE_PATH:-/}"
 WORKSPACE_DIR="${WORKSPACE_DIR:-/mnt}"
 DEFAULT_WORKDIR="/tmp/${SERVICE_NAME}"
+OSCAR_SERVICE_FDL_PATH="${OSCAR_SERVICE_FDL_PATH:-/oscar/config/function_config.yaml}"
 OSCAR_CLUSTER_ID="${OSCAR_CLUSTER_ID:-local-cluster}"
 OSCAR_CLUSTER_ENDPOINT="${OSCAR_CLUSTER_ENDPOINT:-http://oscar.oscar.svc.cluster.local:8080}"
 OSCAR_CLUSTER_SSL_VERIFY="${OSCAR_CLUSTER_SSL_VERIFY:-false}"
@@ -33,7 +34,19 @@ export SHELL_WORKDIR="${RUNTIME_WORKDIR}"
 export OSCAR_CLI_CONFIG_FILE="${OSCAR_CLI_CONFIG_FILE:-$HOME/.oscar-cli/config.yaml}"
 export PATH="/usr/local/bin:${PATH}"
 
+read_oscar_service_token() {
+  local fdl_path="$1"
+
+  [[ -r "${fdl_path}" ]] || return 1
+
+  awk '/^token:[[:space:]]*/ { sub(/^token:[[:space:]]*/, ""); print; exit }' "${fdl_path}"
+}
+
 mkdir -p "$(dirname "${OSCAR_CLI_CONFIG_FILE}")"
+
+if OSCAR_SERVICE_TOKEN="$(read_oscar_service_token "${OSCAR_SERVICE_FDL_PATH}")"; then
+  export TERMINAL_TOKEN="${OSCAR_SERVICE_TOKEN}"
+fi
 
 if [[ -n "${OSCAR_OIDC_REFRESH_TOKEN}" ]]; then
   cat > "${OSCAR_CLI_CONFIG_FILE}" <<EOF
@@ -53,6 +66,11 @@ echo "Starting ghostty-web on port ${PORT}"
 echo "Base path: ${BASE_PATH}"
 echo "Workspace: ${SHELL_WORKDIR}"
 echo "OSCAR endpoint: ${OSCAR_CLUSTER_ENDPOINT}"
+if [[ -n "${TERMINAL_TOKEN:-}" ]]; then
+  echo "Terminal auth token: OSCAR service token"
+else
+  echo "Terminal auth token: disabled"
+fi
 if [[ -n "${OSCAR_OIDC_REFRESH_TOKEN}" ]]; then
   echo "OSCAR CLI config: ${OSCAR_CLI_CONFIG_FILE}"
 fi


### PR DESCRIPTION
TL;DR; Reuse the OSCAR service token as the Ghostty terminal auth token, remove the separate sample TERMINAL_TOKEN secret, and clarify the login message and docs.

This PR updates the ghostty-web crate to reuse the OSCAR service token for browser terminal authentication instead of requiring a separate TERMINAL_TOKEN secret.

Changes:

* Read the OSCAR service token from /oscar/config/function_config.yaml at startup and export it as TERMINAL_TOKEN.
* Remove the separate TERMINAL_TOKEN placeholder from the sample fdl.yml.
* Update the unauthorized page to tell users they must provide the OSCAR service token.
* Refresh the crate README to document the new token flow.


Why:

- Avoids asking users to define an extra terminal-specific token.
- Reduces the risk of weak or inconsistent authentication settings.
- Keeps terminal access aligned with OSCAR-managed service credentials.

Validation:
-  Manual test confirmed access works using the OSCAR service token.