### PR TITLE
Update: remove URLs from OSCAR service metadata

### DIFF
--- a/crates/cowsay/ro-crate-metadata.json
+++ b/crates/cowsay/ro-crate-metadata.json
@@ -64,7 +64,6 @@
         "SoftwareSourceCode"
       ],
       "name": "OSCAR Cowsay Service Definition",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/cowsay/fdl.yml",
       "encodingFormat": "text/yaml"
     },
     {
@@ -74,7 +73,6 @@
         "SoftwareSourceCode"
       ],
       "name": "OSCAR Cowsay Service Script",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/cowsay/script.sh",
       "encodingFormat": "text/x-shellscript"
     },
     {
@@ -84,7 +82,6 @@
         "ImageObject"
       ],
       "name": "OSCAR Cowsay Service Icon",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/cowsay/icon.png",
       "encodingFormat": "image/png"
     },
     {
@@ -95,7 +92,6 @@
       ],
       "name": "Sample Cowsay Input",
       "description": "Example phrase rendered by cowsay; replace or extend with service-specific fixtures.",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/cowsay/input.txt",
       "encodingFormat": "text/plain"
     },
     {

--- a/crates/fish-detector/ro-crate-metadata.json
+++ b/crates/fish-detector/ro-crate-metadata.json
@@ -72,7 +72,6 @@
         "SoftwareSourceCode"
       ],
       "name": "OSCAR Service Definition",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/fish-detector/fdl.yml",
       "encodingFormat": "text/yaml"
     },
     {
@@ -82,7 +81,6 @@
         "SoftwareSourceCode"
       ],
       "name": "OSCAR Service Script",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/fish-detector/script.sh",
       "encodingFormat": "text/x-shellscript"
     },
     {
@@ -92,7 +90,6 @@
         "ImageObject"
       ],
       "name": "OSCAR Service Icon",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/fish-detector/icon.png",
       "encodingFormat": "image/png"
     },
     {
@@ -103,7 +100,6 @@
       ],
       "name": "Sample detection image",
       "description": "Replace with a representative image for running the Fish Detector.",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/fish-detector/input.jpg",
       "encodingFormat": "image/jpg"
     },
     {

--- a/crates/ghostty-web/ro-crate-metadata.json
+++ b/crates/ghostty-web/ro-crate-metadata.json
@@ -88,7 +88,6 @@
         "SoftwareSourceCode"
       ],
       "name": "Service Definition (FDL)",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/ghostty-web/fdl.yml",
       "encodingFormat": "text/yaml"
     },
     {
@@ -98,7 +97,6 @@
         "SoftwareSourceCode"
       ],
       "name": "Service Launch Script",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/ghostty-web/script.sh",
       "encodingFormat": "text/x-shellscript"
     },
     {
@@ -108,7 +106,6 @@
         "TextDigitalDocument"
       ],
       "name": "Deployment Notes",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/ghostty-web/README.md",
       "encodingFormat": "text/markdown"
     },
     {
@@ -118,7 +115,6 @@
         "SoftwareSourceCode"
       ],
       "name": "Container Image Definition",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/ghostty-web/docker/Dockerfile",
       "encodingFormat": "text/plain"
     },
     {
@@ -128,7 +124,6 @@
         "SoftwareSourceCode"
       ],
       "name": "Node.js Dependencies",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/ghostty-web/docker/package.json",
       "encodingFormat": "application/json"
     },
     {
@@ -138,7 +133,6 @@
         "SoftwareSourceCode"
       ],
       "name": "Ghostty Web HTTP and WebSocket Server",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/ghostty-web/docker/server.js",
       "encodingFormat": "application/javascript"
     },
     {
@@ -148,7 +142,6 @@
         "ImageObject"
       ],
       "name": "Service Icon",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/ghostty-web/icon.png",
       "encodingFormat": "image/png"
     },
     {

--- a/crates/kokoro-tts/ro-crate-metadata.json
+++ b/crates/kokoro-tts/ro-crate-metadata.json
@@ -72,7 +72,6 @@
         "SoftwareSourceCode"
       ],
       "name": "OSCAR Service Definition",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/kokoro-tts/fdl.yml",
       "encodingFormat": "text/yaml"
     },
     {
@@ -82,7 +81,6 @@
         "SoftwareSourceCode"
       ],
       "name": "OSCAR Service Script",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/kokoro-tts/script.sh",
       "encodingFormat": "text/x-shellscript"
     },
     {
@@ -92,7 +90,6 @@
         "ImageObject"
       ],
       "name": "OSCAR Service Icon",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/kokoro-tts/icon.png",
       "encodingFormat": "image/png"
     },
     {
@@ -102,7 +99,6 @@
       ],
       "name": "Sample configuration file",
       "description": "Replace with a representative .json file containing the message to be processed and its configuration to run the kokoro-tts model.",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/kokoro-tts/input.json",
       "encodingFormat": "text/json"
     },
     {

--- a/crates/plants-classification/ro-crate-metadata.json
+++ b/crates/plants-classification/ro-crate-metadata.json
@@ -78,7 +78,6 @@
         "SoftwareSourceCode"
       ],
       "name": "OSCAR Service Definition",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/plants-classification/fdl.yml",
       "encodingFormat": "text/yaml"
     },
     {
@@ -88,7 +87,6 @@
         "SoftwareSourceCode"
       ],
       "name": "OSCAR Service Script",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/plants-classification/script.sh",
       "encodingFormat": "text/x-shellscript"
     },
     {
@@ -98,7 +96,6 @@
         "ImageObject"
       ],
       "name": "OSCAR Service Icon",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/plants-classification/icon.png",
       "encodingFormat": "image/png"
     },
     {
@@ -109,7 +106,6 @@
       ],
       "name": "Sample detection image",
       "description": "Replace with a representative image for running the Plants Classification model.",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/plants-classification/input.png",
       "encodingFormat": "image/png"
     },
     {

--- a/crates/posenet-tf/ro-crate-metadata.json
+++ b/crates/posenet-tf/ro-crate-metadata.json
@@ -93,7 +93,6 @@
         "SoftwareSourceCode"
       ],
       "name": "Service Definition (FDL)",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/posenet-tf/fdl.yml",
       "encodingFormat": "text/yaml"
     },
     {
@@ -103,7 +102,6 @@
         "SoftwareSourceCode"
       ],
       "name": "Service Execution Script",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/posenet-tf/script.sh",
       "encodingFormat": "text/x-shellscript"
     },
     {
@@ -113,7 +111,6 @@
         "SoftwareSourceCode"
       ],
       "name": "Service Notes",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/posenet-tf/README.md",
       "encodingFormat": "text/markdown"
     },
     {
@@ -124,7 +121,6 @@
       ],
       "name": "Sample body pose image",
       "description": "JPEG image used to validate the exposed PoseNet prediction endpoint.",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/posenet-tf/001.jpg",
       "encodingFormat": "image/jpeg"
     },
     {
@@ -134,7 +130,6 @@
         "ImageObject"
       ],
       "name": "Service Icon",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/posenet-tf/icon.png",
       "encodingFormat": "image/png"
     },
     {

--- a/crates/simple-test/ro-crate-metadata.json
+++ b/crates/simple-test/ro-crate-metadata.json
@@ -67,7 +67,6 @@
         "SoftwareSourceCode"
       ],
       "name": "OSCAR Simple Test Definition",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/simple-test/fdl.yml",
       "encodingFormat": "text/yaml"
     },
     {
@@ -77,7 +76,6 @@
         "SoftwareSourceCode"
       ],
       "name": "OSCAR Simple Test Script",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/simple-test/script.sh",
       "encodingFormat": "text/x-shellscript"
     },
     {
@@ -87,7 +85,6 @@
         "TextDigitalDocument"
       ],
       "name": "Sample Input",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/simple-test/input.txt",
       "encodingFormat": "text/plain"
     },
     {

--- a/crates/stress-test/ro-crate-metadata.json
+++ b/crates/stress-test/ro-crate-metadata.json
@@ -70,7 +70,6 @@
         "SoftwareSourceCode"
       ],
       "name": "OSCAR Stress Test Definition",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/stress-test/fdl.yml",
       "encodingFormat": "text/yaml"
     },
     {
@@ -80,7 +79,6 @@
         "SoftwareSourceCode"
       ],
       "name": "OSCAR Stress Test Script",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/stress-test/script.sh",
       "encodingFormat": "text/x-shellscript"
     },
     {
@@ -90,7 +88,6 @@
         "ImageObject"
       ],
       "name": "OSCAR Stress Test Service Icon",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/stress-test/icon.png",
       "encodingFormat": "image/png"
     },
     {
@@ -100,7 +97,6 @@
         "TextDigitalDocument"
       ],
       "name": "Sample Input",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/stress-test/input.txt",
       "encodingFormat": "text/plain"
     },
     {

--- a/crates/vllm-llama/ro-crate-metadata.json
+++ b/crates/vllm-llama/ro-crate-metadata.json
@@ -61,7 +61,6 @@
         "SoftwareSourceCode"
       ],
       "name": "Service Definition (FDL)",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/vllm-llama/fdl.yml",
       "encodingFormat": "text/yaml"
     },
     {
@@ -71,7 +70,6 @@
         "SoftwareSourceCode"
       ],
       "name": "Service Execution Script",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/vllm-llama/script.sh",
       "encodingFormat": "text/x-shellscript"
     },
     {
@@ -81,7 +79,6 @@
         "ImageObject"
       ],
       "name": "Service Icon",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/vllm-llama/icon.png",
       "encodingFormat": "image/png"
     },
     {

--- a/crates/vosk-stt/ro-crate-metadata.json
+++ b/crates/vosk-stt/ro-crate-metadata.json
@@ -72,7 +72,6 @@
         "SoftwareSourceCode"
       ],
       "name": "OSCAR Service Definition",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/vosk-stt/fdl.yml",
       "encodingFormat": "text/yaml"
     },
     {
@@ -82,7 +81,6 @@
         "SoftwareSourceCode"
       ],
       "name": "OSCAR Service Script",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/vosk-stt/script.sh",
       "encodingFormat": "text/x-shellscript"
     },
     {
@@ -92,7 +90,6 @@
         "ImageObject"
       ],
       "name": "OSCAR Service Icon",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/vosk-stt/icon.png",
       "encodingFormat": "image/png"
     },
     {
@@ -102,7 +99,6 @@
       ],
       "name": "Sample audio input",
       "description": "Replace with the audio file so that it can be processed by vosk-stt model.",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/vosk-stt/input_en.wav",
       "encodingFormat": "audio/wav"
     },
     {

--- a/crates/yolov8/ro-crate-metadata.json
+++ b/crates/yolov8/ro-crate-metadata.json
@@ -72,7 +72,6 @@
         "SoftwareSourceCode"
       ],
       "name": "OSCAR Service Definition",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/yolov8/fdl.yml",
       "encodingFormat": "text/yaml"
     },
     {
@@ -82,7 +81,6 @@
         "SoftwareSourceCode"
       ],
       "name": "OSCAR Service Script",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/yolov8/script.sh",
       "encodingFormat": "text/x-shellscript"
     },
     {
@@ -92,7 +90,6 @@
         "ImageObject"
       ],
       "name": "OSCAR Service Icon",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/yolov8/icon.png",
       "encodingFormat": "image/png"
     },
     {
@@ -103,7 +100,6 @@
       ],
       "name": "Sample detection image",
       "description": "Replace with a representative image for running the YOLOv8 detector.",
-      "url": "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/yolov8/input.png",
       "encodingFormat": "image/png"
     },
     {


### PR DESCRIPTION
This pull request removes the `url` fields from all file entries in the `ro-crate-metadata.json` files across multiple service crates. This change means that the metadata no longer includes direct links to the raw source files, scripts, icons, and sample input files in the repository. The update likely aims to decouple the metadata from specific repository URLs, possibly to improve portability or reduce maintenance overhead.

**Metadata cleanup and decoupling from repository URLs:**

* Removed the `url` field from all file entries in `crates/cowsay/ro-crate-metadata.json`, affecting references to service definitions, scripts, icons, and sample input files. [[1]](diffhunk://#diff-279731107156d31b1745b676cd7e584631a236249803761da940224916484570L67) [[2]](diffhunk://#diff-279731107156d31b1745b676cd7e584631a236249803761da940224916484570L77) [[3]](diffhunk://#diff-279731107156d31b1745b676cd7e584631a236249803761da940224916484570L87) [[4]](diffhunk://#diff-279731107156d31b1745b676cd7e584631a236249803761da940224916484570L98)
* Removed the `url` field from all file entries in `crates/fish-detector/ro-crate-metadata.json`, including service definitions, scripts, icons, and sample input images. [[1]](diffhunk://#diff-5954536e574b2ab70248757c06a94bcaa20863e6eeaadedf9fdff2bd5ed58dd4L75) [[2]](diffhunk://#diff-5954536e574b2ab70248757c06a94bcaa20863e6eeaadedf9fdff2bd5ed58dd4L85) [[3]](diffhunk://#diff-5954536e574b2ab70248757c06a94bcaa20863e6eeaadedf9fdff2bd5ed58dd4L95) [[4]](diffhunk://#diff-5954536e574b2ab70248757c06a94bcaa20863e6eeaadedf9fdff2bd5ed58dd4L106)
* Removed the `url` field from all file entries in `crates/ghostty-web/ro-crate-metadata.json`, covering service definitions, scripts, documentation, Dockerfiles, dependencies, server code, and icons. [[1]](diffhunk://#diff-06dbd54cc153e02b55ae97e7da173807854ad50fac7e0902c72f33e6049bada0L91) [[2]](diffhunk://#diff-06dbd54cc153e02b55ae97e7da173807854ad50fac7e0902c72f33e6049bada0L101) [[3]](diffhunk://#diff-06dbd54cc153e02b55ae97e7da173807854ad50fac7e0902c72f33e6049bada0L111) [[4]](diffhunk://#diff-06dbd54cc153e02b55ae97e7da173807854ad50fac7e0902c72f33e6049bada0L121) [[5]](diffhunk://#diff-06dbd54cc153e02b55ae97e7da173807854ad50fac7e0902c72f33e6049bada0L131) [[6]](diffhunk://#diff-06dbd54cc153e02b55ae97e7da173807854ad50fac7e0902c72f33e6049bada0L141) [[7]](diffhunk://#diff-06dbd54cc153e02b55ae97e7da173807854ad50fac7e0902c72f33e6049bada0L151)
* Removed the `url` field from all file entries in `crates/kokoro-tts/ro-crate-metadata.json`, including service definitions, scripts, icons, and sample configuration files. [[1]](diffhunk://#diff-3ce71466ed0115f0b434c170af5415bb67b7faf7bb327be75aee59e8e3568327L75) [[2]](diffhunk://#diff-3ce71466ed0115f0b434c170af5415bb67b7faf7bb327be75aee59e8e3568327L85) [[3]](diffhunk://#diff-3ce71466ed0115f0b434c170af5415bb67b7faf7bb327be75aee59e8e3568327L95) [[4]](diffhunk://#diff-3ce71466ed0115f0b434c170af5415bb67b7faf7bb327be75aee59e8e3568327L105)
* Removed the `url` field from all file entries in `crates/plants-classification/ro-crate-metadata.json`, including service definitions, scripts, icons, and sample input images. [[1]](diffhunk://#diff-c4c46436d5d5539ced9d827a004f632c83a7a74e2a911883f7e6c09cede24e44L81) [[2]](diffhunk://#diff-c4c46436d5d5539ced9d827a004f632c83a7a74e2a911883f7e6c09cede24e44L91) [[3]](diffhunk://#diff-c4c46436d5d5539ced9d827a004f632c83a7a74e2a911883f7e6c09cede24e44L101) [[4]](diffhunk://#diff-c4c46436d5d5539ced9d827a004f632c83a7a74e2a911883f7e6c09cede24e44L112)
* Removed the `url` field from all file entries in `crates/posenet-tf/ro-crate-metadata.json`, including service definitions, scripts, notes, sample images, and icons. [[1]](diffhunk://#diff-4990b350ceea8ab95e23758f166b4050607e15c7c67f6ab0f7fd9131a311e5c4L96) [[2]](diffhunk://#diff-4990b350ceea8ab95e23758f166b4050607e15c7c67f6ab0f7fd9131a311e5c4L106) [[3]](diffhunk://#diff-4990b350ceea8ab95e23758f166b4050607e15c7c67f6ab0f7fd9131a311e5c4L116) [[4]](diffhunk://#diff-4990b350ceea8ab95e23758f166b4050607e15c7c67f6ab0f7fd9131a311e5c4L127) [[5]](diffhunk://#diff-4990b350ceea8ab95e23758f166b4050607e15c7c67f6ab0f7fd9131a311e5c4L137)
* Removed the `url` field from all file entries in `crates/simple-test/ro-crate-metadata.json`, including service definitions, scripts, and sample input files. [[1]](diffhunk://#diff-c96f5b3252dfa438e5bf7281f09c5273ed1979bf9771c0c21e6fd79296123f49L70) [[2]](diffhunk://#diff-c96f5b3252dfa438e5bf7281f09c5273ed1979bf9771c0c21e6fd79296123f49L80) [[3]](diffhunk://#diff-c96f5b3252dfa438e5bf7281f09c5273ed1979bf9771c0c21e6fd79296123f49L90)
* Removed the `url` field from all file entries in `crates/stress-test/ro-crate-metadata.json`, including service definitions, scripts, icons, and sample input files. [[1]](diffhunk://#diff-1c63e48b5ffac452faa81c7964a149908218538fa04f9e06ebe8eb418fce51faL73) [[2]](diffhunk://#diff-1c63e48b5ffac452faa81c7964a149908218538fa04f9e06ebe8eb418fce51faL83) [[3]](diffhunk://#diff-1c63e48b5ffac452faa81c7964a149908218538fa04f9e06ebe8eb418fce51faL93) [[4]](diffhunk://#diff-1c63e48b5ffac452faa81c7964a149908218538fa04f9e06ebe8eb418fce51faL103)
* Removed the `url` field from all file entries in `crates/vllm-llama/ro-crate-metadata.json`, including service definitions, scripts, and icons. [[1]](diffhunk://#diff-cc20fdedbad6ce358de63e6fa7b2be1b5ab83c729f5ae1d0dd4b0d8457ee2f62L64) [[2]](diffhunk://#diff-cc20fdedbad6ce358de63e6fa7b2be1b5ab83c729f5ae1d0dd4b0d8457ee2f62L74) [[3]](diffhunk://#diff-cc20fdedbad6ce358de63e6fa7b2be1b5ab83c729f5ae1d0dd4b0d8457ee2f62L84)
* Removed the `url` field from the service definition entry in `crates/vosk-stt/ro-crate-metadata.json`.