### PR TITLE
fix: ensure GPU support is enabled for vllm-gpu-llama

### DIFF
--- a/crates/vllm-llama/fdl.yml
+++ b/crates/vllm-llama/fdl.yml
@@ -3,6 +3,7 @@ functions:
   - oscar-cluster:
       name: vllm-gpu-llama
       cpu: '2.0'
+      enable_gpu: true
       memory: 10Gi
       image: ghcr.io/grycap/vllm-llama
       script: script.sh


### PR DESCRIPTION
Configuration update:

* Added the `enable_gpu: true` option to the `oscar-cluster` function definition in `fdl.yml`, ensure GPU resources.