### PR TITLE
fix: update filebrowser image tag to stable version

### DIFF
--- a/crates/filebrowser-quantum/fdl.yml
+++ b/crates/filebrowser-quantum/fdl.yml
@@ -4,7 +4,7 @@ functions:
       name: filebrowser-quantum
       cpu: "0.5"
       memory: 512Mi
-      image: ghcr.io/gtsteffaniak/filebrowser:latest
+      image: ghcr.io/gtsteffaniak/filebrowser:1.2.4-stable
       script: script.sh
       log_level: INFO
       volume:


### PR DESCRIPTION
**Problem**

The give an error

```bash
Starting FileBrowser Quantum on port 80
Base path: /system/services/hub-kuhezo-s9crh2hi/exposed/
Service name: hub-kuhezo-s9crh2hi
Source path: /data
2026/04/27 12:16:42 [DEBUG] Default SQLite driver initialized
2026/04/27 12:16:42 [WARN ] database file could not be found. If this is unexpected, please set the FILEBROWSER_DATABASE environment variable to the correct path.
2026/04/27 12:16:42 [INFO ] Using admin password from FILEBROWSER_ADMIN_PASSWORD environment variable
2026/04/27 12:16:42 [INFO ] cache directory setup successfully: tmp
2026/04/27 12:16:43 [INFO ] Initializing FileBrowser Quantum (v1.3.0-stable)
2026/04/27 12:16:43 [INFO ] Using Config file        : /home/filebrowser/data/config.yaml
2026/04/27 12:16:43 [INFO ] Auth Methods             : [password]
2026/04/27 12:16:43 [INFO ] Creating new database    : /home/filebrowser/data/database.db
2026/04/27 12:16:43 [INFO ] Sources                  : [data: /data]
2026/04/27 12:16:43 [INFO ] SQL Journal Mode         : OFF
2026/04/27 12:16:43 [INFO ] Resetting admin user to default username and password.
2026/04/27 12:16:43 [INFO ] initializing index: [data]
2026/04/27 12:16:43 [INFO ] Generating PWA icons...
2026/04/27 12:16:43 [INFO ] Running at               : http://0.0.0.0/system/services/hub-kuhezo-s9crh2hi/exposed/
2026/04/27 12:16:43 [FATAL] Server error: listen tcp 0.0.0.0:80: bind: permission denied
```

**Fix**

* Updated the Docker image in `fdl.yml` from `latest` to the specific stable version `1.2.4-stable` for `filebrowser-quantum`.