### PR TITLE
Pin simple-test Ubuntu image

### DIFF
--- a/crates/simple-test/fdl.yml
+++ b/crates/simple-test/fdl.yml
@@ -4,7 +4,7 @@ functions:
      name: simple-test
      memory: 256Mi
      cpu: '1.0'
-     image: ubuntu
+     image: ubuntu:22.04
      script: script.sh
      allowed_users: []
      log_level: CRITICAL		


### PR DESCRIPTION
## Summary
- Pin the simple-test OSCAR Hub example image from ubuntu to ubuntu:22.04.

## Rationale
- Avoid changes in the floating ubuntu tag from altering example behavior.
- Prevent runtime incompatibilities like supervisor crashes observed when the current ubuntu tag resolves to a newer release.

## Validation
- Parsed crates/simple-test/fdl.yml with Ruby YAML.
- Checked the staged diff is limited to the image tag change.