### PR TITLE
Update fish-detector image version to 1.0.1

### DIFF
--- a/crates/fish-detector/fdl.yml
+++ b/crates/fish-detector/fdl.yml
@@ -4,7 +4,7 @@ functions:
      name: fish-detector
      memory: 3Gi
      cpu: '1.0'
-     image: ghcr.io/grycap/fish-detector:1.0.0
+     image: ghcr.io/grycap/fish-detector:1.0.1
      script: script.sh
      log_level: DEBUG
      input:


### PR DESCRIPTION
**Configuration update:**
  * Updated the `image` field for the `fish-detector` function from `ghcr.io/grycap/fish-detector:1.0.0` to `ghcr.io/grycap/fish-detector:1.0.1` to use the latest version.